### PR TITLE
Disable compression for faster unzipping

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,7 +21,7 @@ rm -rf .vagrant
 
 cd ..
 
-zip -r build/vvv.zip tmp
+zip -r -Z store build/vvv.zip tmp
 
 rm -rf tmp
 


### PR DESCRIPTION
Large thumb drives are relatively cheap, but time at a contributor day is limited. With this change, `vvv.zip` becomes `488MB`, so `build` will still fit on a 2GB drive.
