### PR TITLE
Precise placement of resource files in the build

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -34,6 +34,8 @@ curl -L  https://releases.hashicorp.com/vagrant/1.9.5/vagrant_1.9.5_x86_64.dmg -
 curl -L  http://download.virtualbox.org/virtualbox/5.1.22/VirtualBox-5.1.22-115126-Win.exe -o build/windows/virtualbox.exe
 curl -L  http://download.virtualbox.org/virtualbox/5.1.22/VirtualBox-5.1.22-115126-OSX.dmg -o build/osx/virtualbox.dmg
 
+cp resources/linux.txt build/linux/linux.txt
+
 # There's already a copy of vvv-custom.yml in the build folder from earlier
 rm build/vvv-custom.yml
 

--- a/run.sh
+++ b/run.sh
@@ -35,5 +35,4 @@ curl -L  http://download.virtualbox.org/virtualbox/5.1.22/VirtualBox-5.1.22-1151
 curl -L  http://download.virtualbox.org/virtualbox/5.1.22/VirtualBox-5.1.22-115126-OSX.dmg -o build/osx/virtualbox.dmg
 
 cp resources/linux.txt build/linux/linux.txt
-
-cp resources/* build/
+cp resources/instructions.html build/instructions.html

--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,4 @@ curl -L  http://download.virtualbox.org/virtualbox/5.1.22/VirtualBox-5.1.22-1151
 
 cp resources/linux.txt build/linux/linux.txt
 
-# There's already a copy of vvv-custom.yml in the build folder from earlier
-rm build/vvv-custom.yml
-
 cp resources/* build/


### PR DESCRIPTION
This is just a minor change to the build script to ensure that **linux.txt** and **instructions.html** make it into the **build** directory so they are available when its contents get copied to a USB drive.